### PR TITLE
Detect and try to repair redis connection failures

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Runs on Heroku with Redis To Go at the nano level seem to indicate that
redis connections drop without warning, especially after idle.  Try to
detect and recover from this by prefixing operation clusters with a PING
to see if the connection is working, and reopen it if not.

Also improve logging of connection state, and have tests integrate
server logging into the test log flow.
