### PR TITLE
Fix brain-dead redis configuration error.

### DIFF
--- a/cmd/susen/main.go
+++ b/cmd/susen/main.go
@@ -267,12 +267,7 @@ func (session *susenSession) rootHandler(w http.ResponseWriter, r *http.Request)
 
 func main() {
 	// establish redis connection
-	url := os.Getenv("REDISTOGO_URL")
-	if url == "" {
-		rdUrl = "redis://localhost:6379/0"
-	} else {
-		rdUrl = url + "0"
-	}
+	url := redisUrl()
 	if err := redisConnect(url); err != nil {
 		log.Fatalf("Exiting: No redis server at %q: %v", url, err)
 	}
@@ -311,6 +306,16 @@ func main() {
 	if err != nil {
 		log.Fatal("Listener failure: ", err)
 	}
+}
+
+func redisUrl() string {
+	url := os.Getenv("REDISTOGO_URL")
+	if url == "" {
+		url = "redis://localhost:6379/0"
+	} else {
+		url = url + "0"
+	}
+	return url
 }
 
 // redisConnect: connect to the given Redis URL.  Returns the

--- a/cmd/susen/main_test.go
+++ b/cmd/susen/main_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -44,14 +43,8 @@ type sessionClient struct {
 func rdcConnect(t *testing.T) {
 	log.SetOutput(tLogger{t})
 
-	url := os.Getenv("REDISTOGO_URL")
-	if url == "" {
-		url = "redis://localhost:6379/0"
-	} else {
-		url = url + "0"
-	}
-	err := redisConnect(url)
-	if err != nil {
+	url := redisUrl()
+	if err := redisConnect(url); err != nil {
 		t.Fatalf("Exiting: Can't connect to redis at %q: %v", url, err)
 	}
 }


### PR DESCRIPTION
Note to self: always configure the tests and the mainline with the same code. Sheesh.
